### PR TITLE
Add register tests with negative scenarios and utils

### DIFF
--- a/pages/register.page.ts
+++ b/pages/register.page.ts
@@ -1,0 +1,91 @@
+import { Page, Locator } from "@playwright/test";
+import { BasePage } from "./BasePage";
+
+type RegisterUser = {
+  firstName?: string;
+  lastName?: string;
+  dob?: string;
+  street?: string;
+  postalCode?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  phone?: string;
+  emailAddress?: string;
+  password?: string;
+};
+
+export class RegisterPage extends BasePage {
+  readonly signInLink: Locator;
+  readonly createAccountLink: Locator;
+  readonly firstName: Locator;
+  readonly lastName: Locator;
+  readonly dateOfBirth: Locator;
+  readonly street: Locator;
+  readonly postalCode: Locator;
+  readonly city: Locator;
+  readonly state: Locator;
+  readonly country: Locator;
+  readonly phone: Locator;
+  readonly emailAddress: Locator;
+  readonly password: Locator;
+  readonly registerButton: Locator;
+  readonly passwordToggleIcon: Locator;
+  readonly strengthBarFill: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.signInLink = page.getByRole("link", { name: /sign in/i });
+    this.createAccountLink = page.getByRole("link", { name: /register/i });
+    this.firstName = page.locator("#first_name");
+    this.lastName = page.locator("#last_name");
+    this.dateOfBirth = page.locator("#dob");
+    this.street = page.locator("#street");
+    this.postalCode = page.locator("#postal_code");
+    this.city = page.locator("#city");
+    this.state = page.locator("#state");
+    this.country = page.locator("#country");
+    this.phone = page.locator("#phone");
+    this.emailAddress = page.locator("#email");
+    this.password = page.locator("#password");
+    this.registerButton = page.locator(".btnSubmit");
+    this.passwordToggleIcon = page.locator(".btn-outline-secondary");
+    this.strengthBarFill = page.locator(".strength-bar .fill");
+
+    //this.passwordToggleIcon = page.locator('[data-test="password"]');
+  }
+  async navigateToRegister() {
+    await this.page.goto("/");
+    await this.signInLink.click();
+    await this.createAccountLink.click();
+  }
+
+  async registerUser(data: RegisterUser) {
+    if (data.firstName !== undefined) await this.firstName.fill(data.firstName);
+
+    if (data.lastName !== undefined) await this.lastName.fill(data.lastName);
+
+    if (data.dob !== undefined) await this.dateOfBirth.fill(data.dob);
+
+    if (data.street !== undefined) await this.street.fill(data.street);
+
+    if (data.postalCode !== undefined)
+      await this.postalCode.fill(data.postalCode);
+
+    if (data.city !== undefined) await this.city.fill(data.city);
+
+    if (data.state !== undefined) await this.state.fill(data.state);
+
+    if (data.country !== undefined)
+      await this.country.selectOption({ label: data.country });
+
+    if (data.phone !== undefined) await this.phone.fill(data.phone);
+
+    if (data.emailAddress !== undefined)
+      await this.emailAddress.fill(data.emailAddress);
+
+    if (data.password !== undefined) await this.password.fill(data.password);
+
+    await this.registerButton.click();
+  }
+}

--- a/test-data/registerData.ts
+++ b/test-data/registerData.ts
@@ -1,0 +1,12 @@
+export const registerData = {
+  firstName: "Anca",
+  lastName: "Nechita",
+  dob: "1990-05-25",
+  street: "Main Street",
+  postalCode: "710717",
+  city: "Botosani",
+  state: "Botosani",
+  country: "Romania",
+  phone: "0789321243",
+  password: "PasswordLess123@",
+};

--- a/test-data/users.json
+++ b/test-data/users.json
@@ -1,0 +1,21 @@
+{
+                  "validUser":{
+                                    "email":"customer@practicesoftwaretesting.com",
+                                    "password":"Password123"
+                  }, 
+                  "invalidEmail":{
+                                    "email": "wrong@example.com",
+                                    "password": "WrongPassword"
+                  },
+                  "invalidPassword":{
+                  "email": "customer@practicesoftwaretesting.com",
+                  "password": "WrongPassword"},
+
+                  "blank fields" :{"email":"",
+                  "password": ""
+                  },  
+                  "invalidFormatEmail": {
+                  "email": "854u84yt895y8yr.com",
+                  "password":"Password123"
+                     }          
+}

--- a/tests/register.page.spec.ts
+++ b/tests/register.page.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+import { BasePage } from "../pages/BasePage";
+import { RegisterPage } from "../pages/register.page";
+import { registerData } from "../test-data/registerData";
+import { generateRandomEmail } from "../utils/generateRandomEmail";
+
+test.describe("register", () => {
+  let registerPage: RegisterPage;
+
+  test.beforeEach(async ({ page }) => {
+    registerPage = new RegisterPage(page);
+    await registerPage.navigateToRegister();
+  });
+  test("register - happy flow - should create account successfully", async ({
+    page,
+  }) => {
+    const email = generateRandomEmail();
+
+    await registerPage.registerUser({
+      ...registerData,
+      emailAddress: generateRandomEmail(),
+    });
+    await expect(page).toHaveURL(/account|login|success/i);
+  });
+  test("register - negative scenario-missing first name - should not create account", async ({
+    page,
+  }) => {
+    const email = generateRandomEmail();
+
+    await registerPage.registerUser({
+      ...registerData,
+      firstName: "",
+      emailAddress: generateRandomEmail(),
+    });
+    await expect(page).not.toHaveURL(/account/);
+    await expect(page.getByText(" First name is required ")).toBeVisible();
+  });
+  test("register - negative scenario-invalid date of birth format - should not create account", async ({
+    page,
+  }) => {
+    const email = generateRandomEmail();
+
+    await registerPage.registerUser({
+      ...registerData,
+      dob: "25.05.1990",
+      emailAddress: generateRandomEmail(),
+    });
+    await expect(page).not.toHaveURL(/account/);
+    await expect(
+      page.getByText("Please enter a valid date in YYYY-MM-DD format."),
+    ).toBeVisible();
+  });
+  test("register - negative scenario-invalid email format - should not create account", async ({
+    page,
+  }) => {
+    await registerPage.registerUser({
+      ...registerData,
+
+      emailAddress: "email@@address",
+    });
+    await expect(page).not.toHaveURL(/account/);
+    await expect(page.getByText("Email format is invalid")).toBeVisible();
+  });
+  test("register - negative scenario-invalid phone format - should not create account", async ({
+    page,
+  }) => {
+    const email = generateRandomEmail();
+
+    await registerPage.registerUser({
+      ...registerData,
+
+      phone: "telephone",
+      emailAddress: generateRandomEmail(),
+    });
+    await expect(page).not.toHaveURL(/account/);
+    await expect(page.getByText("Only numbers are allowed.")).toBeVisible();
+  });
+
+  test("register - password visibility toogle should work correctly", async ({
+    page,
+  }) => {
+    await expect(registerPage.password).toHaveAttribute("type", "password");
+    await registerPage.passwordToggleIcon.click();
+    await expect(registerPage.password).toHaveAttribute("type", "text");
+    await registerPage.passwordToggleIcon.click();
+    await expect(registerPage.password).toHaveAttribute("type", "password");
+  });
+  test("register - password strength should be weak for simple password", async ({
+    page,
+  }) => {
+    await registerPage.password.fill("123");
+    await expect(registerPage.strengthBarFill).toHaveAttribute(
+      "style",
+      "width: 20%;",
+    );
+  });
+  test("register - password strength should be excellent for complex password", async ({
+    page,
+  }) => {
+    await registerPage.password.fill("Password123@");
+    await expect(registerPage.strengthBarFill).toHaveAttribute(
+      "style",
+      /width:\s?100%/,
+    );
+  });
+});

--- a/utils/generateRandomEmail.ts
+++ b/utils/generateRandomEmail.ts
@@ -1,0 +1,3 @@
+export function generateRandomEmail(): string {
+  return `anca_${Date.now()}@test.com`;
+}


### PR DESCRIPTION
This PR adds:

Register happy flow test

Negative scenarios (missing first name, invalid email, existing email)

Password visibility toggle test

Password strength validation

Refactored register method to use typed object (RegisterUser)